### PR TITLE
Log a warning when the user provides -P if the output file is present but empty

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -441,6 +441,15 @@ def cli(
     # Proxy with a LocalRequirementsRepository if --upgrade is not specified
     # (= default invocation)
     if not upgrade and os.path.exists(output_file.name):
+        if upgrade_install_reqs and os.path.getsize(output_file.name) == 0:
+            log.warning(
+                f"WARNING: the output file {output_file.name} exists but is empty. "
+                "Pip-tools cannot upgrade only specific packages (using -P/--upgrade-package) "
+                "without an existing pin file to provide constraints. "
+                "This often occurs if you redirect standard output to your output file, "
+                "as any existing content is truncated."
+            )
+
         # Use a temporary repository to ensure outdated(removed) options from
         # existing requirements.txt wouldn't get into the current repository.
         tmp_repository = PyPIRepository(pip_args, cache_dir=cache_dir)

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -858,6 +858,24 @@ def test_upgrade_packages_option_no_existing_file(pip_conf, runner):
     assert out.exit_code == 0
     assert "small-fake-a==0.2" in out.stderr.splitlines()
     assert "small-fake-b==0.3" in out.stderr.splitlines()
+    assert "WARNING: the output file requirements.txt exists but is empty" not in out.stderr
+
+def test_upgrade_packages_option_empty_existing_file_warning(pip_conf, runner):
+    """
+    piptools warns the user if --upgrade-package/-P is specified and the
+    output file exists, but is empty.
+    """
+    with open("requirements.in", "w") as req_in:
+        req_in.write("small-fake-a==0.2")
+    with open("requirements.txt", "w") as req_txt:
+        req_txt.write("")
+
+    out = runner.invoke(cli, ["--no-annotate", "-P", "small-fake-a"])
+
+    assert out.exit_code == 0
+    assert "small-fake-a==0.2" in out.stderr.splitlines()
+    assert "WARNING: the output file requirements.txt exists but is empty" in out.stderr
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When the user runs a command like

```
pip-compile -P some_package requirements.in
```

the expected behavior is that only `some_package` should be updated to a new version.

If the user errs by redirecting `pip-compile`'s stdout to the target file:

```
pip-compile -P some_package requirements.in > requirements.txt
```

instead of either using `-o` or allowing `pip-compile` to infer the target file name, the target file is truncated by the shell before `pip-compile` executes. This results in `pip-compile` actually updating _all_ dependencies, because while the target file is present, it's not a valid source of version constraints.

This PR adds a check in the code to detect this situation, which is almost certainly undesired, and redirect the user to a more appropriate command.

##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
